### PR TITLE
BUG: transfer_image function

### DIFF
--- a/src/disko/image_management/image_controller.py
+++ b/src/disko/image_management/image_controller.py
@@ -67,7 +67,7 @@ class ImageController:
         self.docker_client.login(username=username, password=password)
 
         # Pull the image
-        pulled_image = self.docker_client.images.pull(image)
+        pulled_image = self.docker_client.images.pull(image, tag)
         if pulled_image:
             print(f"Image {image} pulled successfully")
 


### PR DESCRIPTION
The copy_images function is calling transfer_image function to transfer copy the image, there was a bug the pulling was not possible with an image tag that isn't latest.